### PR TITLE
oval: create reference index for use with Lookup methods

### DIFF
--- a/oval/objects.go
+++ b/oval/objects.go
@@ -5,60 +5,59 @@ import (
 	"sync"
 )
 
+func (o *Objects) init() {
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		o.lineMemo = make(map[string]int, len(o.LineObjects))
+		for i, v := range o.LineObjects {
+			o.lineMemo[v.ID] = i
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		o.version55Memo = make(map[string]int, len(o.Version55Objects))
+		for i, v := range o.Version55Objects {
+			o.version55Memo[v.ID] = i
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		o.rpminfoMemo = make(map[string]int, len(o.RPMInfoObjects))
+		for i, v := range o.RPMInfoObjects {
+			o.rpminfoMemo[v.ID] = i
+		}
+	}()
+
+	wg.Wait()
+}
+
 // Lookup returns the kind of object and index into that kind-specific slice, if
 // found.
 func (o *Objects) Lookup(ref string) (kind string, index int, err error) {
+	o.once.Do(o.init)
+	if i, ok := o.lineMemo[ref]; ok {
+		return o.LineObjects[i].XMLName.Local, i, nil
+	}
+
+	if i, ok := o.version55Memo[ref]; ok {
+		return o.Version55Objects[i].XMLName.Local, i, nil
+	}
+	if i, ok := o.rpminfoMemo[ref]; ok {
+		return o.RPMInfoObjects[i].XMLName.Local, i, nil
+	}
+
+	// We didn't find it, maybe we can say why.
 	id, err := ParseID(ref)
 	if err != nil {
 		return "", -1, err
 	}
 	if id.Type != OvalObject {
 		return "", -1, fmt.Errorf("oval: wrong identifier type %q", id.Type)
-	}
-	type result struct {
-		kind  string
-		index int
-	}
-	ch := make(chan *result)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(3)
-	go func() {
-		defer wg.Done()
-		for i, t := range o.LineObjects {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for i, t := range o.Version55Objects {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for i, t := range o.RPMInfoObjects {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case r := <-ch:
-		return r.kind, r.index, nil
-	case <-done:
 	}
 	return "", -1, ErrNotFound
 }

--- a/oval/rpminfo_test.go
+++ b/oval/rpminfo_test.go
@@ -22,10 +22,14 @@ func TestLookupRPMIntoObject(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tc := range tt {
-		obj := root.Objects.LookupRPMInfoObject(tc.Ref)
-		if obj == nil {
-			t.Fatal("exepected to find object, got nil")
+		kind, i, err := root.Objects.Lookup(tc.Ref)
+		if err != nil {
+			t.Error(err)
 		}
+		if got, want := kind, "rpminfo_object"; got != want {
+			t.Errorf("got: %q, want %q", got, want)
+		}
+		obj := &root.Objects.RPMInfoObjects[i]
 		t.Logf("%s: %s (%#+v)", tc.Ref, obj.Name, obj)
 		if got, want := obj.Name, tc.Name; got != want {
 			t.Fatalf("got: %q, want: %q", got, want)

--- a/oval/tests.go
+++ b/oval/tests.go
@@ -5,60 +5,61 @@ import (
 	"sync"
 )
 
+// Init sets up the memoization maps.
+func (t *Tests) init() {
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		t.lineMemo = make(map[string]int, len(t.LineTests))
+		for i, v := range t.LineTests {
+			t.lineMemo[v.ID] = i
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		t.version55Memo = make(map[string]int, len(t.Version55Tests))
+		for i, v := range t.Version55Tests {
+			t.version55Memo[v.ID] = i
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		t.rpminfoMemo = make(map[string]int, len(t.RPMInfoTests))
+		for i, v := range t.RPMInfoTests {
+			t.rpminfoMemo[v.ID] = i
+		}
+	}()
+
+	wg.Wait()
+}
+
 // Lookup returns the kind of test and index into that kind-specific slice, if
 // found.
 func (t *Tests) Lookup(ref string) (kind string, index int, err error) {
+	// Pay to construct an index, once.
+	t.once.Do(t.init)
+
+	if i, ok := t.lineMemo[ref]; ok {
+		return t.LineTests[i].XMLName.Local, i, nil
+	}
+	if i, ok := t.version55Memo[ref]; ok {
+		return t.Version55Tests[i].XMLName.Local, i, nil
+	}
+	if i, ok := t.rpminfoMemo[ref]; ok {
+		return t.RPMInfoTests[i].XMLName.Local, i, nil
+	}
+
+	// We didn't find it, maybe we can say why.
 	id, err := ParseID(ref)
 	if err != nil {
 		return "", -1, err
 	}
 	if id.Type != OvalTest {
 		return "", -1, fmt.Errorf("oval: wrong identifier type %q", id.Type)
-	}
-	type result struct {
-		kind  string
-		index int
-	}
-	ch := make(chan *result)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(3)
-	go func() {
-		defer wg.Done()
-		for i, t := range t.LineTests {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for i, t := range t.Version55Tests {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for i, t := range t.RPMInfoTests {
-			if t.ID == ref {
-				ch <- &result{t.XMLName.Local, i}
-				break
-			}
-		}
-	}()
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case r := <-ch:
-		return r.kind, r.index, nil
-	case <-done:
 	}
 	return "", -1, ErrNotFound
 }

--- a/oval/types.go
+++ b/oval/types.go
@@ -3,6 +3,7 @@ package oval
 import (
 	"encoding/xml"
 	"errors"
+	"sync"
 )
 
 // ErrNotFound is returned by Lookup methods when the specified identifier is
@@ -142,10 +143,14 @@ type Debian struct {
 
 // Tests : >tests
 type Tests struct {
+	once           sync.Once
 	XMLName        xml.Name        `xml:"tests"`
 	LineTests      []LineTest      `xml:"line_test"`
 	Version55Tests []Version55Test `xml:"version55_test"`
 	RPMInfoTests   []RPMInfoTest   `xml:"rpminfo_test"`
+	lineMemo       map[string]int
+	version55Memo  map[string]int
+	rpminfoMemo    map[string]int
 }
 
 // ObjectRef : >tests>line_test>object-object_ref
@@ -164,16 +169,24 @@ type StateRef struct {
 
 // Objects : >objects
 type Objects struct {
+	once             sync.Once
 	XMLName          xml.Name          `xml:"objects"`
 	LineObjects      []LineObject      `xml:"line_object"`
 	Version55Objects []Version55Object `xml:"version55_object"`
 	RPMInfoObjects   []RPMInfoObject   `xml:"rpminfo_object"`
+	lineMemo         map[string]int
+	version55Memo    map[string]int
+	rpminfoMemo      map[string]int
 }
 
 // States : >states
 type States struct {
+	once            sync.Once
 	XMLName         xml.Name         `xml:"states"`
 	LineStates      []LineState      `xml:"line_state"`
 	Version55States []Version55State `xml:"version55_state"`
 	RPMInfoStates   []RPMInfoState   `xml:"rpminfo_state"`
+	lineMemo        map[string]int
+	version55Memo   map[string]int
+	rpminfoMemo     map[string]int
 }


### PR DESCRIPTION
This commit implements an index for the various Lookup methods. There
was a memoized lookup in previous versions of the Lookup methods, but
through an oversight it didn't make it into the committed version.

The runtime to construct the index is paid on the first call of a Lookup
method. A sync.Once is used to make sure it's only done once and that
the method remains concurrent-OK.

This also defers parsing the reference until after a lookup has failed,
which saves allocations and provides the same error messages.

This also fixes a broken test to use the correct, generic Lookup method.