### PR TITLE
parsing: handle invalid date

### DIFF
--- a/oval/types.go
+++ b/oval/types.go
@@ -150,7 +150,8 @@ func (d *Date) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		time.RFC1123Z,
 		time.RFC3339,
 		time.RFC3339Nano,
-		"2006-01-02 15:04:05", // Ubuntu style `YYYY-MM-DD time`, for when you want to seem precise.
+		"2006-01-02 15:04:05",    // Ubuntu style `YYYY-MM-DD time`, for when you want to seem precise.
+		"2006-01-02 15:04:05 PT", // Ubuntu style `YYYY-MM-DD time invalid-timezone`, note: this loses the timezone precision.
 	} {
 		d.Date, err = time.Parse(f, s)
 		if err == nil {


### PR DESCRIPTION
Ubuntu's OVAL DB is returning dates that the library is unable
parse, eg. "2021-07-19 12:00:00 PT", this change accounts for
that specific situation and loses the timezone precision, which
is not great. It is possible that some manual parsing before
date.Parse() might be needed. Issue: https://github.com/quay/goval-parser/issues/9

Signed-off-by: crozzy <joseph.crosland@gmail.com>