### PR TITLE
oval: handle unknown for date fields

### DIFF
--- a/oval/date_test.go
+++ b/oval/date_test.go
@@ -126,14 +126,29 @@ func TestUbuntuDates(t *testing.T) {
 	}
 }
 
-func TestPointlessElement(t *testing.T) {
-	const doc = xml.Header + `<div><issued date=""/></div>`
+func TestBadDateElements(t *testing.T) {
 	var got struct {
 		Date Date `xml:"issued"`
 	}
 
-	rd := strings.NewReader(doc)
-	if err := xml.NewDecoder(rd).Decode(&got); err != nil {
-		t.Error(err)
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "TestPointlessElement",
+			in:   `<div><issued date=""/></div>`,
+		},
+		{
+			name: "TestUnknown",
+			in:   `<div><issued>unknown</issued></div>`,
+		},
+	}
+	for _, test := range tests {
+		doc := xml.Header + test.in
+		rd := strings.NewReader(doc)
+		if err := xml.NewDecoder(rd).Decode(&got); err != nil {
+			t.Error(test.name, err)
+		}
 	}
 }

--- a/oval/types.go
+++ b/oval/types.go
@@ -149,6 +149,10 @@ func (d *Date) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		// pointless but we need to not return an error.
 		d.Date = time.Time{}
 		return nil
+	case s == "unknown":
+		// Ubuntu occasionally add vulnerability definitions with "unknown" in the date field.
+		d.Date = time.Time{}
+		return nil
 	case s == "" && !d.Date.IsZero():
 		// If the date is set but an empty string is the inner element, then the
 		// date was set by an attr.


### PR DESCRIPTION
The Ubuntu feed will surface "unknown" for dates i.e. <public_date>, this currently causes an error until the feed is fixed. This will use an effect zero date instead: time.Time{} 0001-01-01 00:00:00 +0000 UTC

Signed-off-by: crozzy <joseph.crosland@gmail.com>